### PR TITLE
fix(ci): Sanitize PR title

### DIFF
--- a/.github/workflows/dev_pr.yml
+++ b/.github/workflows/dev_pr.yml
@@ -53,5 +53,7 @@ jobs:
           ref: "${{ github.event.pull_request.merge_commit_sha }}"
 
       - name: Check PR title for conventional commit format
+        env:
+          PR_TITLE: ${{ github.event.pull_request.title }}
         run: |
-          python .github/workflows/dev_pr/title_check.py $(pwd)/pr_checkout "${{ github.event.pull_request.title }}"
+          python .github/workflows/dev_pr/title_check.py $(pwd)/pr_checkout "$PR_TITLE"


### PR DESCRIPTION
My scanner picked up this vulnerability added recently. Just making a PR to fix it because the workflow permissions are locked down to just PR and issues write and there are no secrets, so the worst someone could do is be a nuisance or cache poisoning (which attackers don't know how to do...yet).

Ref:

* https://securitylab.github.com/research/github-actions-untrusted-input/